### PR TITLE
Allow multivalued query parameters

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,6 +1,6 @@
 name: CI (Python)
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/postgrest_py/request_builder.py
+++ b/postgrest_py/request_builder.py
@@ -55,10 +55,14 @@ class FilterRequestBuilder(QueryRequestBuilder):
 
     def filter(self, column: str, operator: str, criteria: str):
         """Either filter in or filter out based on Self.negate_next."""
-        if self.negate_next == True:
+        if self.negate_next is True:
             self.negate_next = False
             operator = f"not.{operator}"
-        self.session.params[sanitize_param(column)] = f"{operator}.{criteria}"
+        key, val = sanitize_param(column), f"{operator}.{criteria}"
+        if key in self.session.params:
+            self.session.params.update({key: self.session.params.getlist(key) + [val]})
+        else:
+            self.session.params[key] = val
         return self
 
     def eq(self, column: str, value: str):

--- a/tests/test_filter_request_builder.py
+++ b/tests/test_filter_request_builder.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient, QueryParams
+from httpx import AsyncClient
 from postgrest_py.request_builder import FilterRequestBuilder
 
 

--- a/tests/test_filter_request_builder.py
+++ b/tests/test_filter_request_builder.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, QueryParams
 from postgrest_py.request_builder import FilterRequestBuilder
 
 
@@ -28,3 +28,9 @@ def test_filter(filter_request_builder):
     builder = filter_request_builder.filter(":col.name", "eq", "val")
 
     assert builder.session.params['":col.name"'] == "eq.val"
+
+
+def test_multivalued_param(filter_request_builder):
+    builder = filter_request_builder.lte("x", "a").gte("x", "b")
+
+    assert str(builder.session.params) == "x=lte.a&x=gte.b"


### PR DESCRIPTION
This fix allows to apply several filters to a single column.
Currently every new filter overrides the previous one (e.g. `builder.gte('x', 10).lte('x', 20)` produces `x=lte.20`), this is due to how `httpx.QueryParams.__set__` works. 