### PR TITLE
Allow setting headers in PostgrestClient's constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### _Unreleased_
+
+#### Added
+
+- Allow setting headers in `PostgrestClient`'s constructor
+
 ### v0.4.0
 
 #### Added

--- a/postgrest_py/__init__.py
+++ b/postgrest_py/__init__.py
@@ -1,2 +1,2 @@
 from postgrest_py.__version__ import __version__
-from postgrest_py.client import Client, PostgrestClient
+from postgrest_py.client import DEFAULT_POSTGREST_CLIENT_HEADERS, Client, PostgrestClient

--- a/postgrest_py/client.py
+++ b/postgrest_py/client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 from deprecation import deprecated
 from httpx import AsyncClient, BasicAuth, Response
@@ -6,7 +6,7 @@ from httpx import AsyncClient, BasicAuth, Response
 from postgrest_py.__version__ import __version__
 from postgrest_py.request_builder import RequestBuilder
 
-DEFAULT_POSTGREST_CLIENT_HEADERS: Dict[str, Any] = {
+DEFAULT_POSTGREST_CLIENT_HEADERS: Dict[str, str] = {
     "Accept": "application/json",
     "Content-Type": "application/json",
 }
@@ -19,8 +19,8 @@ class PostgrestClient:
         self,
         base_url: str,
         *,
-        schema="public",
-        headers: Dict[str, Any] = DEFAULT_POSTGREST_CLIENT_HEADERS,
+        schema: str = "public",
+        headers: Dict[str, str] = DEFAULT_POSTGREST_CLIENT_HEADERS,
     ) -> None:
         headers = {
             **headers,
@@ -42,7 +42,7 @@ class PostgrestClient:
         self,
         token: str,
         *,
-        username: Union[str, bytes] = None,
+        username: Union[str, bytes, None] = None,
         password: Union[str, bytes] = "",
     ):
         """Authenticate the client with either bearer token or basic authentication."""

--- a/postgrest_py/client.py
+++ b/postgrest_py/client.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Dict, Union
 
 from deprecation import deprecated
 from httpx import AsyncClient, BasicAuth, Response
@@ -6,14 +6,24 @@ from httpx import AsyncClient, BasicAuth, Response
 from postgrest_py.__version__ import __version__
 from postgrest_py.request_builder import RequestBuilder
 
+DEFAULT_POSTGREST_CLIENT_HEADERS: Dict[str, Any] = {
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+
 
 class PostgrestClient:
     """PostgREST client."""
 
-    def __init__(self, base_url: str, *, schema="public") -> None:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        schema="public",
+        headers: Dict[str, Any] = DEFAULT_POSTGREST_CLIENT_HEADERS,
+    ) -> None:
         headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
+            **headers,
             "Accept-Profile": schema,
             "Content-Profile": schema,
         }
@@ -44,9 +54,7 @@ class PostgrestClient:
 
     def schema(self, schema: str):
         """Switch to another schema."""
-        self.session.headers.update(
-            {"Accept-Profile": schema, "Content-Profile": schema}
-        )
+        self.session.headers.update({"Accept-Profile": schema, "Content-Profile": schema})
         return self
 
     def from_(self, table: str) -> RequestBuilder:


### PR DESCRIPTION
Allow setting headers in `PostgrestClient`'s constructor, prepare a solution for #9.