### PR TITLE
fix: revert sanitize_pattern_param in like and ilike

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -35,13 +35,7 @@ except ImportError:
     from pydantic import validator as field_validator
 
 from .types import CountMethod, Filters, RequestMethod, ReturnMethod
-from .utils import (
-    AsyncClient,
-    SyncClient,
-    get_origin_and_cast,
-    sanitize_param,
-    sanitize_pattern_param,
-)
+from .utils import AsyncClient, SyncClient, get_origin_and_cast, sanitize_param
 
 
 class QueryArgs(NamedTuple):
@@ -347,7 +341,6 @@ class BaseFilterRequestBuilder(Generic[_ReturnT]):
             column: The name of the column to apply a filter on
             pattern: The pattern to filter by
         """
-        pattern = sanitize_pattern_param(pattern)
         return self.filter(column, Filters.LIKE, pattern)
 
     def like_all_of(self: Self, column: str, pattern: str) -> Self:
@@ -397,7 +390,6 @@ class BaseFilterRequestBuilder(Generic[_ReturnT]):
             column: The name of the column to apply a filter on
             pattern: The pattern to filter by
         """
-        pattern = sanitize_pattern_param(pattern)
         return self.filter(column, Filters.ILIKE, pattern)
 
     def or_(self: Self, filters: str, reference_table: Union[str, None] = None) -> Self:

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -190,25 +190,13 @@ def test_overlaps_with_timestamp_range(filter_request_builder):
 def test_like(filter_request_builder):
     builder = filter_request_builder.like("x", "%a%")
 
-    assert str(builder.params) == "x=like.%2Aa%2A"
-
-
-def test_like2(filter_request_builder):
-    builder = filter_request_builder.like("x", f"%{85770204020}%")  # See bug #830.
-
-    assert str(builder.params) == "x=like.%2A85770204020%2A"
+    assert str(builder.params) == "x=like.%a%"
 
 
 def test_ilike(filter_request_builder):
     builder = filter_request_builder.ilike("x", "%a%")
 
-    assert str(builder.params) == "x=ilike.%2Aa%2A"
-
-
-def test_ilike2(filter_request_builder):
-    builder = filter_request_builder.ilike("x", f"%{85770204020}%")  # See bug #830.
-
-    assert str(builder.params) == "x=ilike.%2A85770204020%2A"
+    assert str(builder.params) == "x=ilike.%a%"
 
 
 def test_like_all_of(filter_request_builder):

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -190,25 +190,13 @@ def test_overlaps_with_timestamp_range(filter_request_builder):
 def test_like(filter_request_builder):
     builder = filter_request_builder.like("x", "%a%")
 
-    assert str(builder.params) == "x=like.%2Aa%2A"
-
-
-def test_like2(filter_request_builder):
-    builder = filter_request_builder.like("x", f"%{85770204020}%")  # See bug #830.
-
-    assert str(builder.params) == "x=like.%2A85770204020%2A"
+    assert str(builder.params) == "x=like.%a%"
 
 
 def test_ilike(filter_request_builder):
     builder = filter_request_builder.ilike("x", "%a%")
 
-    assert str(builder.params) == "x=ilike.%2Aa%2A"
-
-
-def test_ilike2(filter_request_builder):
-    builder = filter_request_builder.ilike("x", f"%{85770204020}%")  # See bug #830.
-
-    assert str(builder.params) == "x=ilike.%2A85770204020%2A"
+    assert str(builder.params) == "x=ilike.%a%"
 
 
 def test_like_all_of(filter_request_builder):


### PR DESCRIPTION
Reverts supabase/postgrest-py#461 because it broke functionality of the library. You can see the linked issue for a repro of the issue https://github.com/supabase/postgrest-py/issues/477.