### PR TITLE
fix: add missing on_conflict on update method

### DIFF
--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -371,6 +371,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
         json: dict,
         *,
         count: Optional[CountMethod] = None,
+        on_conflict: Optional[str] = None,
         returning: ReturnMethod = ReturnMethod.representation,
     ) -> AsyncFilterRequestBuilder[_ReturnT]:
         """Run an UPDATE query.
@@ -378,6 +379,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
         Args:
             json: The updated fields.
             count: The method to use to get the count of rows returned.
+            on_conflict: Specified columns to be made to work with UNIQUE constraint.
             returning: Either 'minimal' or 'representation'
         Returns:
             :class:`AsyncFilterRequestBuilder`
@@ -385,6 +387,7 @@ class AsyncRequestBuilder(Generic[_ReturnT]):
         method, params, headers, json = pre_update(
             json,
             count=count,
+            on_conflict=on_conflict,
             returning=returning,
         )
         return AsyncFilterRequestBuilder[_ReturnT](

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -119,13 +119,17 @@ def pre_update(
     json: dict,
     *,
     count: Optional[CountMethod],
+    on_conflict: Optional[str] = None,
     returning: ReturnMethod,
 ) -> QueryArgs:
     prefer_headers = [f"return={returning}"]
     if count:
         prefer_headers.append(f"count={count}")
     headers = Headers({"Prefer": ",".join(prefer_headers)})
-    return QueryArgs(RequestMethod.PATCH, QueryParams(), headers, json)
+    query_params = {}
+    if on_conflict:
+        query_params["on_conflict"] = on_conflict
+    return QueryArgs(RequestMethod.PATCH, QueryParams(query_params), headers, json)
 
 
 def pre_delete(

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -140,6 +140,11 @@ class TestUpdate:
         assert builder.http_method == "PATCH"
         assert builder.json == {"key1": "val1"}
 
+    def test_update_with_on_conflict(self, request_builder: AsyncRequestBuilder):
+        builder = request_builder.update({"key1": "val1"}, on_conflict="key1")
+
+        assert builder.params["on_conflict"] == "key1"
+
 
 class TestDelete:
     def test_delete(self, request_builder: AsyncRequestBuilder):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/postgrest-py/issues/488

## What is the current behavior?

No `on_conflict` param on update method

## What is the new behavior?

Add `on_conflict` param on update method


Docs update: https://github.com/supabase/supabase/pull/28637