### PR TITLE
fix: fixed the 'order' method for 'BaseSelectRequestBuilder'

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -563,9 +563,18 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[_ReturnT]):
         .. versionchanged:: 0.10.3
            Allow ordering results for foreign tables with the foreign_table parameter.
         """
+
+        new_order_parameter = (f"{foreign_table + '(' if foreign_table else ''}{column}{')' if foreign_table else ''}"
+                               f"{'.desc' if desc else ''}{'.nullsfirst' if nullsfirst else ''}")
+
+        existing_order_parameter = self.params.get('order')
+        if existing_order_parameter:
+            self.params = self.params.remove('order')
+            new_order_parameter = f"{existing_order_parameter},{new_order_parameter}"
+
         self.params = self.params.add(
-            f"{foreign_table}.order" if foreign_table else "order",
-            f"{column}{'.desc' if desc else ''}{'.nullsfirst' if nullsfirst else ''}",
+            "order",
+            new_order_parameter,
         )
         return self
 


### PR DESCRIPTION
Fixed the 'order' method for 'BaseSelectRequestBuilder' to support multiple sorting criteria and handle sorting on foreign tables.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Issue: https://github.com/supabase/supabase-py/issues/775

```
response = (
    supabase.table("clones")
    .select("*")
    .eq("owner", uid)
    .order("last_chatted", desc=True)
    .order("created_at", desc=True)
    .execute()
)
```

The problem is that adding several orders generates for QueryParams this: `&order=last_chatted.desc&order=created_at.desc`

Previous workaround:
```
request_build=
    supabase.table("clones")
    .select("*")
    .eq("owner", uid)
    .order("last_chatted", desc=True)
    .order("created_at", desc=True)

#get list of all added orders
removed_orders=request_build.params.get_list('order')

#remove them from QueryParams
request_build.params=request_build.params.remove('order')

#add back by merging them
request_build.params=request_build.params.add('order',','.join(removed_orders))
response =request_build.execute()
```

## What is the new behavior?

```
response = (
    supabase.table("clones")
    .select("*")
    .eq("owner", uid)
    .order("last_chatted", desc=True)
    .order("created_at", desc=True)
    .execute()
)
```
Works as expected and generates QueryParams according to [postgrest docs](https://docs.postgrest.org/en/v12/references/api/tables_views.html) and it looks like: &order=last_chatted.desc,created_at.desc

## Additional context

Add any other context or screenshots.
