### PR TITLE
Cleanout

### DIFF
--- a/postgrest/__init__.py
+++ b/postgrest/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from httpx import Timeout
 
 from ._async.client import AsyncPostgrestClient

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from json import JSONDecodeError
 from typing import Any, Generic, Optional, TypeVar, Union
 

--- a/postgrest/_sync/__init__.py
+++ b/postgrest/_sync/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, Optional, Union, cast
 
 from deprecation import deprecated

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from json import JSONDecodeError
 from typing import Any, Generic, Optional, TypeVar, Union
 

--- a/postgrest/base_client.py
+++ b/postgrest/base_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Union
 

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from json import JSONDecodeError
 from re import search

--- a/postgrest/deprecated_client.py
+++ b/postgrest/deprecated_client.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from deprecation import deprecated
 
 from ._async.client import AsyncPostgrestClient

--- a/postgrest/deprecated_get_request_builder.py
+++ b/postgrest/deprecated_get_request_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from deprecation import deprecated
 
 from ._async.request_builder import AsyncSelectRequestBuilder

--- a/postgrest/types.py
+++ b/postgrest/types.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 
 if sys.version_info >= (3, 11):

--- a/postgrest/utils.py
+++ b/postgrest/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Type, TypeVar, cast, get_origin
 
 from httpx import AsyncClient  # noqa: F401


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Cleanout future imports `from __future__ import annotations` no longer needed for Python >= `3.9.0`.
