### PR TITLE
fix: Types to use Option[T]

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -405,7 +405,7 @@ class BaseFilterRequestBuilder(Generic[_ReturnT]):
         """
         return self.filter(column, Filters.ILIKE, pattern)
 
-    def or_(self: Self, filters: str, reference_table: Union[str, None] = None) -> Self:
+    def or_(self: Self, filters: str, reference_table: Optional[str] = None) -> Self:
         """An 'or' filter
 
         Args:


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix types to use `Option[T]` instead of Unions of Nones.
