### PR TITLE
chore: minimal python version in ci and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Clone Repository

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### Requirements
 
-- Python >= 3.9
+- Python >= 3.8
 - PostgreSQL >= 12
 - PostgREST >= 7
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Installation
 ============
 Requirements:
 
-- Python >= 3.7
+- Python >= 3.8
 
 **With pip:**
 ::


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update docs: python minimal version for installation changed from `3.7` to `3.8`
- Added python `3.8` version to matrix during tests

## What is the current behavior?

#517 

## What is the new behavior?

- Now tests runs on all supported version of python
