### PR TITLE
fix(deps) install strenum package only with Python 3.10 and older

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1524,4 +1524,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c13054793a7c205fb2027d7ca05e434d4511217115a88d919ceed67acc570e66"
+content-hash = "cad18a43ef1fd69cbb4257b42aa0f896046d38f5d1ee821915f97f51d93428a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ python = "^3.9"
 httpx = {version = ">=0.26,<0.28", extras = ["http2"]}
 deprecation = "^2.1.0"
 pydantic = ">=1.9,<3.0"
-strenum = "^0.4.9"
+strenum = {version = "^0.4.9", python = "<3.11"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Install `strenum` package only with Python 3.10 and older

## What is the current behavior?

#518 



