### PR TITLE
fix: _cleaned_columns function now works with python multiline and typings

### DIFF
--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -52,18 +52,21 @@ def _unique_columns(json: List[Dict]):
     return columns
 
 
-def _cleaned_columns(columns: Tuple[str]) -> str:
+def _cleaned_columns(columns: Tuple[str, ...]) -> str:
     quoted = False
-    result = []
+    cleaned = []
 
-    for c in columns:
-        if c.isspace() and not quoted:
-            continue
-        if c == '"':
-            quoted = not quoted
-        result.append(c)
+    for column in columns:
+        clean_column = ""
+        for char in column:
+            if char.isspace() and not quoted:
+                continue
+            if char == '"':
+                quoted = not quoted
+            clean_column += char
+        cleaned.append(clean_column)
 
-    return ",".join(result)
+    return ",".join(cleaned)
 
 
 def pre_select(

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -52,7 +52,7 @@ def _unique_columns(json: List[Dict]):
     return columns
 
 
-def _cleaned_columns(columns: str) -> str:
+def _cleaned_columns(columns: Tuple[str]) -> str:
     quoted = False
     result = []
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Previously `columns` parameter of `def _cleaned_columns` was typed as "str", but actually tuple of strings was passed from `def pre_upsert`. 
The logic inside the function was also made for one string rather than for tuple of strings.

## What is the new behavior?

- The typing is changed to `columns: Tuple[str, ...]`
- Logic inside the function is fixed. Now each column-string is cleaned out of whitespaces.

## Additional context

My custom made test ran without errors:

```python
import unittest
from typing import Tuple


def _cleaned_columns(columns: Tuple[str, ...]) -> str:
    quoted = False
    cleaned = []

    for column in columns:
        clean_column = ""
        for char in column:
            if char.isspace() and not quoted:
                continue
            if char == '"':
                quoted = not quoted
            clean_column += char
        cleaned.append(clean_column)

    return ",".join(cleaned)


def wrap(*columns: str) -> str:
    return _cleaned_columns(columns)


class TestWrapFunction(unittest.TestCase):
    def test_wrap_single_column(self):
        self.assertEqual(wrap("column1"), "column1")

    def test_wrap_multiple_columns(self):
        self.assertEqual(wrap("column1", "column2"), "column1,column2")

    def test_wrap_columns_with_spaces(self):
        self.assertEqual(wrap(" column1 ", " column2 "), "column1,column2")

    def test_wrap_columns_with_quotes(self):
        self.assertEqual(wrap('"column1"', '"column2"'), '"column1","column2"')

    def test_wrap_columns_with_mixed_spaces_and_quotes(self):
        self.assertEqual(wrap(' "column1" ', ' "column2" '), '"column1","column2"')

    def test_wrap_no_columns(self):
        self.assertEqual(wrap(), "")

    def test_wrap_single_column_with_spaces(self):
        self.assertEqual(wrap(" column1 "), "column1")

    def test_wrap_single_column_with_quotes(self):
        self.assertEqual(wrap('"column1"'), '"column1"')

    def test_wrap_mixed_columns(self):
        self.assertEqual(wrap(" column1 ", '"column2"'), 'column1,"column2"')
```
