### PR TITLE
fix!: schema method persisting only on current query

### DIFF
--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -60,6 +60,17 @@ class AsyncPostgrestClient(BasePostgrestClient):
             http2=True,
         )
 
+    def schema(self, schema: str):
+        """Switch to another schema."""
+        return AsyncPostgrestClient(
+            base_url=self.base_url,
+            schema=schema,
+            headers=self.headers,
+            timeout=self.timeout,
+            verify=self.verify,
+            proxy=self.proxy,
+        )
+
     async def __aenter__(self) -> AsyncPostgrestClient:
         return self
 

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -60,6 +60,17 @@ class SyncPostgrestClient(BasePostgrestClient):
             http2=True,
         )
 
+    def schema(self, schema: str):
+        """Switch to another schema."""
+        return SyncPostgrestClient(
+            base_url=self.base_url,
+            schema=schema,
+            headers=self.headers,
+            timeout=self.timeout,
+            verify=self.verify,
+            proxy=self.proxy,
+        )
+
     def __enter__(self) -> SyncPostgrestClient:
         return self
 

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -34,7 +34,7 @@ class SyncQueryRequestBuilder(Generic[_ReturnT]):
         http_method: str,
         headers: Headers,
         params: QueryParams,
-        json: Union[dict, list],
+        json: dict,
     ) -> None:
         self.session = session
         self.path = path
@@ -290,7 +290,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             *columns: The names of the columns to fetch.
             count: The method to use to get the count of rows returned.
         Returns:
-            :class:`SyncSelectRequestBuilder`
+            :class:`AsyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_select(*columns, count=count, head=head)
         return SyncSelectRequestBuilder[_ReturnT](
@@ -317,7 +317,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
                 Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
-            :class:`SyncQueryRequestBuilder`
+            :class:`AsyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_insert(
             json,
@@ -353,7 +353,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
                 not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
-            :class:`SyncQueryRequestBuilder`
+            :class:`AsyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_upsert(
             json,
@@ -381,7 +381,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`SyncFilterRequestBuilder`
+            :class:`AsyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_update(
             json,
@@ -404,7 +404,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`SyncFilterRequestBuilder`
+            :class:`AsyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_delete(
             count=count,

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -290,7 +290,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             *columns: The names of the columns to fetch.
             count: The method to use to get the count of rows returned.
         Returns:
-            :class:`AsyncSelectRequestBuilder`
+            :class:`SyncSelectRequestBuilder`
         """
         method, params, headers, json = pre_select(*columns, count=count, head=head)
         return SyncSelectRequestBuilder[_ReturnT](
@@ -317,7 +317,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
                 Otherwise, use the default value for the column.
                 Only applies for bulk inserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`SyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_insert(
             json,
@@ -353,7 +353,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
                 not when merging with existing rows under `ignoreDuplicates: false`.
                 This also only applies when doing bulk upserts.
         Returns:
-            :class:`AsyncQueryRequestBuilder`
+            :class:`SyncQueryRequestBuilder`
         """
         method, params, headers, json = pre_upsert(
             json,
@@ -381,7 +381,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`SyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_update(
             json,
@@ -404,7 +404,7 @@ class SyncRequestBuilder(Generic[_ReturnT]):
             count: The method to use to get the count of rows returned.
             returning: Either 'minimal' or 'representation'
         Returns:
-            :class:`AsyncFilterRequestBuilder`
+            :class:`SyncFilterRequestBuilder`
         """
         method, params, headers, json = pre_delete(
             count=count,

--- a/postgrest/base_client.py
+++ b/postgrest/base_client.py
@@ -23,12 +23,19 @@ class BasePostgrestClient(ABC):
     ) -> None:
         if not is_http_url(base_url):
             ValueError("base_url must be a valid HTTP URL string")
-        headers = {
+
+        self.base_url = base_url
+        self.headers = {
             **headers,
             "Accept-Profile": schema,
             "Content-Profile": schema,
         }
-        self.session = self.create_session(base_url, headers, timeout, verify, proxy)
+        self.timeout = timeout
+        self.verify = verify
+        self.proxy = proxy
+        self.session = self.create_session(
+            self.base_url, self.headers, self.timeout, self.verify, self.proxy
+        )
 
     @abstractmethod
     def create_session(
@@ -67,14 +74,4 @@ class BasePostgrestClient(ABC):
             raise ValueError(
                 "Neither bearer token or basic authentication scheme is provided"
             )
-        return self
-
-    def schema(self, schema: str):
-        """Switch to another schema."""
-        self.session.headers.update(
-            {
-                "Accept-Profile": schema,
-                "Content-Profile": schema,
-            }
-        )
         return self

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -62,8 +62,8 @@ class TestAuth:
 
 
 def test_schema(postgrest_client: AsyncPostgrestClient):
-    postgrest_client.schema("private")
-    session = postgrest_client.session
+    client = postgrest_client.schema("private")
+    session = client.session
     subheaders = {
         "accept-profile": "private",
         "content-profile": "private",

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -61,8 +61,8 @@ class TestAuth:
 
 
 def test_schema(postgrest_client: SyncPostgrestClient):
-    postgrest_client.schema("private")
-    session = postgrest_client.session
+    client = postgrest_client.schema("private")
+    session = client.session
     subheaders = {
         "accept-profile": "private",
         "content-profile": "private",


### PR DESCRIPTION
## What kind of change does this PR introduce?

The `.schema()` method from this library sets the schema as default, affecting the whole application instead of changing the schema of the current query only.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
