### PR TITLE
fix: order using foreign table

### DIFF
--- a/infra/init.sql
+++ b/infra/init.sql
@@ -76,3 +76,24 @@ create or replace function public.list_stored_countries()
 as $function$
     select * from countries;
 $function$;
+
+
+create table
+  orchestral_sections (id int8 primary key, name text);
+create table
+  instruments (
+    id int8 primary key,
+    section_id int8 not null references orchestral_sections,
+    name text
+  );
+
+insert into
+  orchestral_sections (id, name)
+values
+  (1, 'strings'),
+  (2, 'woodwinds');
+insert into
+  instruments (id, section_id, name)
+values
+  (1, 1, 'harp'),
+  (2, 1, 'violin');

--- a/tests/_async/test_filter_request_builder_integration.py
+++ b/tests/_async/test_filter_request_builder_integration.py
@@ -498,3 +498,18 @@ async def test_order():
         {"country_name": "UNITED STATES", "iso": "US"},
         {"country_name": "UNITED KINGDOM", "iso": "GB"},
     ]
+
+
+async def test_order_on_foreign_table():
+    res = (
+        await rest_client()
+        .from_("orchestral_sections")
+        .select("name, instruments(name)")
+        .order("name", desc=True, foreign_table="instruments")
+        .execute()
+    )
+
+    assert res.data == [
+        {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
+        {"name": "woodwinds", "instruments": []},
+    ]

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -218,10 +218,7 @@ class TestOrder:
             .order("city_name", desc=True, foreign_table=foreign_table)
             .order("id", desc=True, foreign_table=foreign_table)
         )
-        assert (
-            str(builder.params)
-            == "select=%2A&order=cities%28city_name%29.desc%2Ccities%28id%29.desc"
-        )
+        assert str(builder.params) == "select=%2A&cities.order=city_name.desc%2Cid.desc"
 
 
 class TestRange:

--- a/tests/_sync/test_filter_request_builder_integration.py
+++ b/tests/_sync/test_filter_request_builder_integration.py
@@ -491,3 +491,18 @@ def test_order():
         {"country_name": "UNITED STATES", "iso": "US"},
         {"country_name": "UNITED KINGDOM", "iso": "GB"},
     ]
+
+
+def test_order_on_foreign_table():
+    res = (
+        rest_client()
+        .from_("orchestral_sections")
+        .select("name, instruments(name)")
+        .order("name", desc=True, foreign_table="instruments")
+        .execute()
+    )
+
+    assert res.data == [
+        {"name": "strings", "instruments": [{"name": "violin"}, {"name": "harp"}]},
+        {"name": "woodwinds", "instruments": []},
+    ]

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -218,10 +218,7 @@ class TestOrder:
             .order("city_name", desc=True, foreign_table=foreign_table)
             .order("id", desc=True, foreign_table=foreign_table)
         )
-        assert (
-            str(builder.params)
-            == "select=%2A&order=cities%28city_name%29.desc%2Ccities%28id%29.desc"
-        )
+        assert str(builder.params) == "select=%2A&cities.order=city_name.desc%2Cid.desc"
 
 
 class TestRange:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase/postgrest-py/issues/579

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
