### PR TITLE
fix: pass params as query params for get/head requests

### DIFF
--- a/infra/init.sql
+++ b/infra/init.sql
@@ -77,6 +77,12 @@ as $function$
     select * from countries;
 $function$;
 
+create or replace function public.search_countries_by_name(search_name text)
+    returns setof countries
+    language sql
+as $function$
+    select * from countries where nicename ilike '%' || search_name || '%';
+$function$;
 
 create table
   orchestral_sections (id int8 primary key, name text);

--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -133,6 +133,10 @@ class AsyncPostgrestClient(BasePostgrestClient):
 
         headers = Headers({"Prefer": f"count={count}"}) if count else Headers()
 
+        if method in ("HEAD", "GET"):
+            return AsyncRPCFilterRequestBuilder[Any](
+                self.session, f"/rpc/{func}", method, headers, QueryParams(params), json={}
+            )
         # the params here are params to be sent to the RPC and not the queryparams!
         return AsyncRPCFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", method, headers, QueryParams(), json=params

--- a/postgrest/_async/client.py
+++ b/postgrest/_async/client.py
@@ -135,7 +135,12 @@ class AsyncPostgrestClient(BasePostgrestClient):
 
         if method in ("HEAD", "GET"):
             return AsyncRPCFilterRequestBuilder[Any](
-                self.session, f"/rpc/{func}", method, headers, QueryParams(params), json={}
+                self.session,
+                f"/rpc/{func}",
+                method,
+                headers,
+                QueryParams(params),
+                json={},
             )
         # the params here are params to be sent to the RPC and not the queryparams!
         return AsyncRPCFilterRequestBuilder[Any](

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -135,7 +135,12 @@ class SyncPostgrestClient(BasePostgrestClient):
 
         if method in ("HEAD", "GET"):
             return SyncRPCFilterRequestBuilder[Any](
-                self.session, f"/rpc/{func}", method, headers, QueryParams(params), json={}
+                self.session,
+                f"/rpc/{func}",
+                method,
+                headers,
+                QueryParams(params),
+                json={},
             )
         # the params here are params to be sent to the RPC and not the queryparams!
         return SyncRPCFilterRequestBuilder[Any](

--- a/postgrest/_sync/client.py
+++ b/postgrest/_sync/client.py
@@ -133,6 +133,10 @@ class SyncPostgrestClient(BasePostgrestClient):
 
         headers = Headers({"Prefer": f"count={count}"}) if count else Headers()
 
+        if method in ("HEAD", "GET"):
+            return SyncRPCFilterRequestBuilder[Any](
+                self.session, f"/rpc/{func}", method, headers, QueryParams(params), json={}
+            )
         # the params here are params to be sent to the RPC and not the queryparams!
         return SyncRPCFilterRequestBuilder[Any](
             self.session, f"/rpc/{func}", method, headers, QueryParams(), json=params

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -665,8 +665,6 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder[_ReturnT]):
         else:
             self.headers["Prefer"] = "return=representation"
 
-        print(self.headers)
-
         return self
 
     def single(self) -> Self:

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -660,7 +660,7 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder[_ReturnT]):
         """
         method, params, headers, json = pre_select(*columns, count=None)
         self.params = self.params.add("select", params.get("select"))
-        if self.headers.get("prefer"):
+        if self.headers.get("Prefer"):
             self.headers["Prefer"] += ",return=representation"
         else:
             self.headers["Prefer"] = "return=representation"

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -660,7 +660,11 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder[_ReturnT]):
         """
         method, params, headers, json = pre_select(*columns, count=None)
         self.params = self.params.add("select", params.get("select"))
-        self.headers["Prefer"] = "return=representation"
+        if self.headers.get("prefer"):
+            self.headers["Prefer"] += ",return=representation"
+        else:
+            self.headers["Prefer"] = "return=representation"
+
         return self
 
     def single(self) -> Self:

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -665,6 +665,8 @@ class BaseRPCRequestBuilder(BaseSelectRequestBuilder[_ReturnT]):
         else:
             self.headers["Prefer"] = "return=representation"
 
+        print(self.headers)
+
         return self
 
     def single(self) -> Self:

--- a/tests/_sync/test_filter_request_builder_integration.py
+++ b/tests/_sync/test_filter_request_builder_integration.py
@@ -496,6 +496,17 @@ def test_rpc_get_with_args():
     assert res.data == [{"nicename": "Algeria", "iso": "DZ"}]
 
 
+def test_rpc_get_with_count():
+    res = (
+        rest_client()
+        .rpc("search_countries_by_name", {"search_name": "Al"}, get=True, count="exact")
+        .select("nicename")
+        .execute()
+    )
+    assert res.count == 2
+    assert res.data == [{"nicename": "Albania"}, {"nicename": "Algeria"}]
+
+
 def test_rpc_head_count():
     res = (
         rest_client()

--- a/tests/_sync/test_filter_request_builder_integration.py
+++ b/tests/_sync/test_filter_request_builder_integration.py
@@ -476,6 +476,37 @@ def test_rpc_with_range():
     ]
 
 
+def test_rpc_post_with_args():
+    res = (
+        rest_client()
+        .rpc("search_countries_by_name", {"search_name": "Alban"})
+        .select("nicename, iso")
+        .execute()
+    )
+    assert res.data == [{"nicename": "Albania", "iso": "AL"}]
+
+
+def test_rpc_get_with_args():
+    res = (
+        rest_client()
+        .rpc("search_countries_by_name", {"search_name": "Alger"}, get=True)
+        .select("nicename, iso")
+        .execute()
+    )
+    assert res.data == [{"nicename": "Algeria", "iso": "DZ"}]
+
+
+def test_rpc_head_count():
+    res = (
+        rest_client()
+        .rpc("search_countries_by_name", {"search_name": "Al"}, head=True, count="exact")
+        .execute()
+    )
+
+    assert res.count == 2
+    assert res.data == []
+
+
 def test_order():
     res = (
         rest_client()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows using GET and HEAD methods on Postgrest RPC functions with arguments.

## What is the current behavior?

RPC functions always try to send params in the body. This will fail for GET and HEAD methods.

Please link any relevant issues here.

 https://github.com/supabase/postgrest-py/issues/592

## What is the new behavior?

You can now properly use get=True / head=True in postgrest RPC func calls.
