### PR TITLE
fix: validate JSON input for APIError.__init__()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ remove_pytest_asyncio_from_sync:
 	sed -i 's/@pytest.mark.asyncio//g' tests/_sync/test_client.py
 	sed -i 's/_async/_sync/g' tests/_sync/test_client.py
 	sed -i 's/Async/Sync/g' tests/_sync/test_client.py
+	sed -i 's/_client\.SyncClient/_client\.Client/g' tests/_sync/test_client.py
 
 sleep:
 	sleep 2

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from json import JSONDecodeError
 from typing import Any, Generic, Optional, TypeVar, Union
 
 from httpx import Headers, QueryParams

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -19,7 +19,7 @@ from ..base_request_builder import (
     pre_update,
     pre_upsert,
 )
-from ..exceptions import APIError, generate_default_error_message
+from ..exceptions import APIError, APIErrorFromJSON, generate_default_error_message
 from ..types import ReturnMethod
 from ..utils import AsyncClient, get_origin_and_cast
 
@@ -75,10 +75,9 @@ class AsyncQueryRequestBuilder(Generic[_ReturnT]):
                             return body
                 return APIResponse[_ReturnT].from_http_request_response(r)
             else:
-                raise APIError(r.json())
+                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                raise APIError(dict(json_obj))
         except ValidationError as e:
-            raise APIError(r.json()) from e
-        except JSONDecodeError:
             raise APIError(generate_default_error_message(r))
 
 
@@ -124,10 +123,9 @@ class AsyncSingleRequestBuilder(Generic[_ReturnT]):
             ):  # Response.ok from JS (https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
                 return SingleAPIResponse[_ReturnT].from_http_request_response(r)
             else:
-                raise APIError(r.json())
+                json_obj = APIErrorFromJSON.model_validate_json(r.content)
+                raise APIError(dict(json_obj))
         except ValidationError as e:
-            raise APIError(r.json()) from e
-        except JSONDecodeError:
             raise APIError(generate_default_error_message(r))
 
 

--- a/postgrest/exceptions.py
+++ b/postgrest/exceptions.py
@@ -1,5 +1,20 @@
 from typing import Dict, Optional
+from pydantic import BaseModel
 
+
+class APIErrorFromJSON(BaseModel):
+    """
+    A pydantic object to validate an error info object
+    from a json string.
+    """
+    message: Optional[str]
+    """The error message."""
+    code: Optional[str]
+    """The error code."""
+    hint: Optional[str]
+    """The error hint."""
+    details: Optional[str]
+    """The error details."""
 
 class APIError(Exception):
     """

--- a/postgrest/exceptions.py
+++ b/postgrest/exceptions.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional
+
 from pydantic import BaseModel
 
 
@@ -7,6 +8,7 @@ class APIErrorFromJSON(BaseModel):
     A pydantic object to validate an error info object
     from a json string.
     """
+
     message: Optional[str]
     """The error message."""
     code: Optional[str]
@@ -15,6 +17,7 @@ class APIErrorFromJSON(BaseModel):
     """The error hint."""
     details: Optional[str]
     """The error details."""
+
 
 class APIError(Exception):
     """

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from httpx import BasicAuth, Headers, Response, Request
+from httpx import BasicAuth, Headers, Request, Response
 
 from postgrest import AsyncPostgrestClient
 from postgrest.exceptions import APIError
@@ -107,6 +107,7 @@ async def test_response_status_code_outside_ok(postgrest_client: AsyncPostgrestC
         )
         assert exc_response["errors"][0].get("code") == 400
 
+
 @pytest.mark.asyncio
 async def test_response_maybe_single(postgrest_client: AsyncPostgrestClient):
     with patch(
@@ -127,20 +128,21 @@ async def test_response_maybe_single(postgrest_client: AsyncPostgrestClient):
         assert isinstance(exc_response.get("message"), str)
         assert "code" in exc_response and int(exc_response["code"]) == 204
 
+
 # https://github.com/supabase/postgrest-py/issues/595
 @pytest.mark.asyncio
-async def test_response_client_invalid_response_but_valid_json(postgrest_client: AsyncPostgrestClient):
+async def test_response_client_invalid_response_but_valid_json(
+    postgrest_client: AsyncPostgrestClient,
+):
     with patch(
         "httpx._client.AsyncClient.request",
         return_value=Response(
             status_code=502,
-            text='"gateway error: Error: Network connection lost."', # quotes makes this text a valid non-dict JSON object
-            request=Request(method="GET", url="http://example.com")
-        )
+            text='"gateway error: Error: Network connection lost."',  # quotes makes this text a valid non-dict JSON object
+            request=Request(method="GET", url="http://example.com"),
+        ),
     ):
-        client = (
-            postgrest_client.from_("test").select("a", "b").eq("c", "d").single()
-        )
+        client = postgrest_client.from_("test").select("a", "b").eq("c", "d").single()
         assert "Accept" in client.headers
         assert client.headers.get("Accept") == "application/vnd.pgrst.object+json"
         with pytest.raises(APIError) as exc_info:

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -132,7 +132,7 @@ def test_response_client_invalid_response_but_valid_json(
     postgrest_client: SyncPostgrestClient,
 ):
     with patch(
-        "httpx._client.SyncClient.request",
+        "httpx._client.Client.request",
         return_value=Response(
             status_code=502,
             text='"gateway error: Error: Network connection lost."',  # quotes makes this text a valid non-dict JSON object

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from httpx import BasicAuth, Headers
+from httpx import BasicAuth, Headers, Request, Response
 
 from postgrest import SyncPostgrestClient
 from postgrest.exceptions import APIError
@@ -123,3 +123,29 @@ def test_response_maybe_single(postgrest_client: SyncPostgrestClient):
         exc_response = exc_info.value.json()
         assert isinstance(exc_response.get("message"), str)
         assert "code" in exc_response and int(exc_response["code"]) == 204
+
+
+# https://github.com/supabase/postgrest-py/issues/595
+
+
+def test_response_client_invalid_response_but_valid_json(
+    postgrest_client: SyncPostgrestClient,
+):
+    with patch(
+        "httpx._client.SyncClient.request",
+        return_value=Response(
+            status_code=502,
+            text='"gateway error: Error: Network connection lost."',  # quotes makes this text a valid non-dict JSON object
+            request=Request(method="GET", url="http://example.com"),
+        ),
+    ):
+        client = postgrest_client.from_("test").select("a", "b").eq("c", "d").single()
+        assert "Accept" in client.headers
+        assert client.headers.get("Accept") == "application/vnd.pgrst.object+json"
+        with pytest.raises(APIError) as exc_info:
+            client.execute()
+        assert isinstance(exc_info, pytest.ExceptionInfo)
+        exc_response = exc_info.value.json()
+        assert isinstance(exc_response.get("message"), str)
+        assert exc_response.get("message") == "JSON could not be generated"
+        assert "code" in exc_response and int(exc_response["code"]) == 502


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduce validation that the error received on a request has the the correct JSON schema, as reported by #595.

## What is the current behavior?

Currently, if a request is not successful, it will try to convert its response to JSON by using `r.json()`, correctly ensuring that the `JSONDecodeError` is dealt with in the try block. However, given that `r.json()` returns `Any`, it is not guaranteed to be a `Dict[str, str]` as the `APIError.__init__()` method expects, and thus if an error response returns a valid non-dict JSON object, such as text surrounded by quotes (a valid JSON string) the initializer will throw an `AttributeError` when trying to access one of the JSON object's methods.

## What is the new behavior?

A simple `APIErrorFromJSON` pydantic model is introduced, to throw a `ValidationError` in the case of the response content not being JSON, or if it is valid JSON but not a valid expected schema. This simplifies the code a little bit, as `JSONDecodeError` does not need to be handled anymore, because it was thrown by the `.json()` method on the `Response`. I've also added a new test to ensure that this behavior is taken into account from now on.

## Additional context

This could be handled by adding some check akin to `isinstance(r.json(), dict)`, but this only handles the first layer of the validation, and it would need to validate that the keys are also of the expected type. This is exactly what `pydantic` does, so I believe it to be the better solution overall.
