### PR TITLE
chore: replace isort, black, pyupgrade and autoflake with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,43 +9,17 @@ repos:
           - id: mixed-line-ending
             args: ["--fix=lf"]
 
-    - repo: https://github.com/pycqa/isort
-      rev: "6.0.0"
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.12.1
       hooks:
-          - id: isort
-            args:
-                [
-                    "--profile",
-                    "black",
-                    "--multi-line=3",
-                    "--trailing-comma",
-                    "--force-grid-wrap=0",
-                    "--use-parentheses",
-                    "--line-width=88",
-                ]
-
-    - repo: https://github.com/PyCQA/autoflake.git
-      rev: v2.3.1
-      hooks:
-          - id: autoflake
-            args:
-                [
-                    "--in-place",
-                    "--remove-all-unused-imports",
-                    "--ignore-init-module-imports",
-                ]
-
-    - repo: https://github.com/psf/black
-      rev: "24.4.0"
-      hooks:
-          - id: black
-            args: [--line-length, "90"]
-
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v3.15.2
-      hooks:
-          - id: pyupgrade
-            args: ["--py37-plus", "--keep-runtime-typing"]
+        # Run the linter.
+        - id: ruff
+          types_or: [ python, pyi ]
+          args: [ --fix ]
+        # Run the formatter.
+        - id: ruff-format
+          types_or: [ python, pyi ]
 
     - repo: https://github.com/commitizen-tools/commitizen
       rev: v3.22.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,53 +85,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "black"
-version = "25.1.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
-    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
-    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
-    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
-    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
-    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
-    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
-    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
-    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
-    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
-    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
-    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
-    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
-    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
-    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
-    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
-    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
-    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
-    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
-    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
-    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
-    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -436,23 +389,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e"},
-    {file = "flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.14.0,<2.15.0"
-pyflakes = ">=3.4.0,<3.5.0"
-
-[[package]]
 name = "furo"
 version = "2024.8.6"
 description = "A clean customisable Sphinx documentation theme."
@@ -665,22 +601,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "6.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
-    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -770,30 +690,6 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "networkx"
 version = "3.2.1"
 description = "Python package for creating and manipulating graphs and networks"
@@ -834,18 +730,6 @@ groups = ["main", "dev", "docs"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
@@ -899,18 +783,6 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
-    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
-]
 
 [[package]]
 name = "pydantic"
@@ -1045,18 +917,6 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"},
-    {file = "pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58"},
-]
 
 [[package]]
 name = "pygments"
@@ -1239,6 +1099,34 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "ruff"
+version = "0.12.1"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b"},
+    {file = "ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0"},
+    {file = "ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed"},
+    {file = "ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c"},
+    {file = "ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6"},
+    {file = "ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245"},
+    {file = "ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013"},
+    {file = "ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc"},
+    {file = "ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c"},
+]
 
 [[package]]
 name = "setuptools"
@@ -1553,7 +1441,7 @@ files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
-markers = {dev = "python_version < \"3.11\""}
+markers = {dev = "python_version < \"3.10\""}
 
 [[package]]
 name = "typing-inspection"
@@ -1670,4 +1558,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "3974292923e1edbf638a276563bc16324c42f93531a4e70f05771989efb591b4"
+content-hash = "a8cceb1f4206d6957cde0feaa00db30bfae2b5af6e14cfaf346ec4472e252784"

--- a/postgrest/_async/request_builder.py
+++ b/postgrest/_async/request_builder.py
@@ -149,7 +149,9 @@ class AsyncMaybeSingleRequestBuilder(AsyncSingleRequestBuilder[_ReturnT]):
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class AsyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], AsyncQueryRequestBuilder[_ReturnT]):  # type: ignore
+class AsyncFilterRequestBuilder(
+    BaseFilterRequestBuilder[_ReturnT], AsyncQueryRequestBuilder[_ReturnT]
+):  # type: ignore
     def __init__(
         self,
         session: AsyncClient,
@@ -189,7 +191,9 @@ class AsyncRPCFilterRequestBuilder(
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class AsyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], AsyncQueryRequestBuilder[_ReturnT]):  # type: ignore
+class AsyncSelectRequestBuilder(
+    BaseSelectRequestBuilder[_ReturnT], AsyncQueryRequestBuilder[_ReturnT]
+):  # type: ignore
     def __init__(
         self,
         session: AsyncClient,

--- a/postgrest/_sync/request_builder.py
+++ b/postgrest/_sync/request_builder.py
@@ -149,7 +149,9 @@ class SyncMaybeSingleRequestBuilder(SyncSingleRequestBuilder[_ReturnT]):
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class SyncFilterRequestBuilder(BaseFilterRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]):  # type: ignore
+class SyncFilterRequestBuilder(
+    BaseFilterRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]
+):  # type: ignore
     def __init__(
         self,
         session: Client,
@@ -189,7 +191,9 @@ class SyncRPCFilterRequestBuilder(
 
 
 # ignoring type checking as a workaround for https://github.com/python/mypy/issues/9319
-class SyncSelectRequestBuilder(BaseSelectRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]):  # type: ignore
+class SyncSelectRequestBuilder(
+    BaseSelectRequestBuilder[_ReturnT], SyncQueryRequestBuilder[_ReturnT]
+):  # type: ignore
     def __init__(
         self,
         session: Client,

--- a/postgrest/base_request_builder.py
+++ b/postgrest/base_request_builder.py
@@ -609,7 +609,7 @@ class BaseSelectRequestBuilder(BaseFilterRequestBuilder[_ReturnT]):
         )
         return self
 
-    def offset(self: _FilterT, size: int) -> _FilterT:
+    def offset(self: Self, size: int) -> Self:
         """Set the starting row index returned by a query.
         Args:
             size: The number of the row to start at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,14 @@ deprecation = "^2.1.0"
 pydantic = ">=1.9,<3.0"
 strenum = {version = "^0.4.9", python = "<3.11"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"
-flake8 = "^7.3.0"
-black = "^25.1"
-isort = "^6.0.1"
 pre-commit = "^4.2.0"
 pytest-cov = "^6.2.1"
 pytest-depends = "^1.0.1"
 pytest-asyncio = "^1.0.0"
 unasync-cli = { git = "https://github.com/supabase-community/unasync-cli.git", branch = "main" }
+ruff = "^0.12.1"
 
 [tool.poetry.group.docs]
 optional = true
@@ -41,6 +39,28 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "^7.1.2"
 furo = ">=2023.9.10,<2025.0.0"
+
+[tool.ruff.lint]
+select = [
+  # pycodestyle
+  "E",
+  # Pyflakes
+  "F",
+  # pyupgrade
+  "UP",
+  # flake8-bugbear
+  # "B",
+  # flake8-simplify
+  # "SIM",
+  # isort
+  "I",
+]
+ignore = ["F401", "F403", "F841", "E712", "E501", "E402", "UP006", "UP035"]
+# isort.required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -130,9 +130,9 @@ async def test_response_status_code_outside_ok(postgrest_client: AsyncPostgrestC
         ),
     ):
         with pytest.raises(APIError) as exc_info:
-            await postgrest_client.from_("test").select("a", "b").eq(
-                "c", "d"
-            ).execute()  # gives status_code = 400
+            await (
+                postgrest_client.from_("test").select("a", "b").eq("c", "d").execute()
+            )  # gives status_code = 400
         exc_response = exc_info.value.json()
         assert not exc_response.get("success")
         assert isinstance(exc_response.get("errors"), list)

--- a/tests/_async/test_filter_request_builder.py
+++ b/tests/_async/test_filter_request_builder.py
@@ -19,7 +19,7 @@ def test_constructor(filter_request_builder: AsyncFilterRequestBuilder):
     assert len(builder.headers) == 0
     assert len(builder.params) == 0
     assert builder.http_method == "GET"
-    assert builder.json == None
+    assert builder.json is None
     assert not builder.negate_next
 
 
@@ -172,7 +172,9 @@ def test_overlaps(filter_request_builder):
 
 
 def test_overlaps_with_timestamp_range(filter_request_builder):
-    builder = filter_request_builder.overlaps("x", "[2000-01-01 12:45, 2000-01-01 13:15)")
+    builder = filter_request_builder.overlaps(
+        "x", "[2000-01-01 12:45, 2000-01-01 13:15)"
+    )
 
     # {a,["b",+"c"]}
     assert str(builder.params) == "x=ov.%5B2000-01-01+12%3A45%2C+2000-01-01+13%3A15%29"

--- a/tests/_async/test_query_request_builder.py
+++ b/tests/_async/test_query_request_builder.py
@@ -19,4 +19,4 @@ def test_constructor(query_request_builder: AsyncQueryRequestBuilder):
     assert len(builder.headers) == 0
     assert len(builder.params) == 0
     assert builder.http_method == "GET"
-    assert builder.json == None
+    assert builder.json is None

--- a/tests/_async/test_request_builder.py
+++ b/tests/_async/test_request_builder.py
@@ -25,7 +25,7 @@ class TestSelect:
         assert builder.params["select"] == "col1,col2"
         assert builder.headers.get("prefer") is None
         assert builder.http_method == "GET"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_with_count(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.select(count=CountMethod.exact)
@@ -33,7 +33,7 @@ class TestSelect:
         assert builder.params["select"] == "*"
         assert builder.headers["prefer"] == "count=exact"
         assert builder.http_method == "GET"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_with_head(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.select("col1", "col2", head=True)
@@ -41,7 +41,7 @@ class TestSelect:
         assert builder.params.get("select") == "col1,col2"
         assert builder.headers.get("prefer") is None
         assert builder.http_method == "HEAD"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_as_csv(self, request_builder: AsyncRequestBuilder):
         builder = request_builder.select("*").csv()
@@ -194,7 +194,9 @@ class TestExplain:
         )
         assert builder.params["select"] == "*"
         assert "application/vnd.pgrst.plan+json;" in str(builder.headers.get("accept"))
-        assert "options=analyze|verbose|buffers|wal" in str(builder.headers.get("accept"))
+        assert "options=analyze|verbose|buffers|wal" in str(
+            builder.headers.get("accept")
+        )
 
 
 class TestOrder:
@@ -210,7 +212,9 @@ class TestOrder:
         )
         assert str(builder.params) == "select=%2A&order=country_name.desc%2Ciso.desc"
 
-    def test_multiple_orders_on_foreign_table(self, request_builder: AsyncRequestBuilder):
+    def test_multiple_orders_on_foreign_table(
+        self, request_builder: AsyncRequestBuilder
+    ):
         foreign_table = "cities"
         builder = (
             request_builder.select()

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -55,7 +55,6 @@ class TestConstructor:
 
 
 class TestHttpxClientConstructor:
-
     def test_custom_httpx_client(self):
         transport = HTTPTransport(
             retries=10,
@@ -127,9 +126,9 @@ def test_response_status_code_outside_ok(postgrest_client: SyncPostgrestClient):
         ),
     ):
         with pytest.raises(APIError) as exc_info:
-            postgrest_client.from_("test").select("a", "b").eq(
-                "c", "d"
-            ).execute()  # gives status_code = 400
+            (
+                postgrest_client.from_("test").select("a", "b").eq("c", "d").execute()
+            )  # gives status_code = 400
         exc_response = exc_info.value.json()
         assert not exc_response.get("success")
         assert isinstance(exc_response.get("errors"), list)

--- a/tests/_sync/test_filter_request_builder.py
+++ b/tests/_sync/test_filter_request_builder.py
@@ -19,7 +19,7 @@ def test_constructor(filter_request_builder: SyncFilterRequestBuilder):
     assert len(builder.headers) == 0
     assert len(builder.params) == 0
     assert builder.http_method == "GET"
-    assert builder.json == None
+    assert builder.json is None
     assert not builder.negate_next
 
 
@@ -172,7 +172,9 @@ def test_overlaps(filter_request_builder):
 
 
 def test_overlaps_with_timestamp_range(filter_request_builder):
-    builder = filter_request_builder.overlaps("x", "[2000-01-01 12:45, 2000-01-01 13:15)")
+    builder = filter_request_builder.overlaps(
+        "x", "[2000-01-01 12:45, 2000-01-01 13:15)"
+    )
 
     # {a,["b",+"c"]}
     assert str(builder.params) == "x=ov.%5B2000-01-01+12%3A45%2C+2000-01-01+13%3A15%29"

--- a/tests/_sync/test_query_request_builder.py
+++ b/tests/_sync/test_query_request_builder.py
@@ -19,4 +19,4 @@ def test_constructor(query_request_builder: SyncQueryRequestBuilder):
     assert len(builder.headers) == 0
     assert len(builder.params) == 0
     assert builder.http_method == "GET"
-    assert builder.json == None
+    assert builder.json is None

--- a/tests/_sync/test_request_builder.py
+++ b/tests/_sync/test_request_builder.py
@@ -25,7 +25,7 @@ class TestSelect:
         assert builder.params["select"] == "col1,col2"
         assert builder.headers.get("prefer") is None
         assert builder.http_method == "GET"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_with_count(self, request_builder: SyncRequestBuilder):
         builder = request_builder.select(count=CountMethod.exact)
@@ -33,7 +33,7 @@ class TestSelect:
         assert builder.params["select"] == "*"
         assert builder.headers["prefer"] == "count=exact"
         assert builder.http_method == "GET"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_with_head(self, request_builder: SyncRequestBuilder):
         builder = request_builder.select("col1", "col2", head=True)
@@ -41,7 +41,7 @@ class TestSelect:
         assert builder.params.get("select") == "col1,col2"
         assert builder.headers.get("prefer") is None
         assert builder.http_method == "HEAD"
-        assert builder.json == None
+        assert builder.json is None
 
     def test_select_as_csv(self, request_builder: SyncRequestBuilder):
         builder = request_builder.select("*").csv()
@@ -194,7 +194,9 @@ class TestExplain:
         )
         assert builder.params["select"] == "*"
         assert "application/vnd.pgrst.plan+json;" in str(builder.headers.get("accept"))
-        assert "options=analyze|verbose|buffers|wal" in str(builder.headers.get("accept"))
+        assert "options=analyze|verbose|buffers|wal" in str(
+            builder.headers.get("accept")
+        )
 
 
 class TestOrder:
@@ -210,7 +212,9 @@ class TestOrder:
         )
         assert str(builder.params) == "select=%2A&order=country_name.desc%2Ciso.desc"
 
-    def test_multiple_orders_on_foreign_table(self, request_builder: SyncRequestBuilder):
+    def test_multiple_orders_on_foreign_table(
+        self, request_builder: SyncRequestBuilder
+    ):
         foreign_table = "cities"
         builder = (
             request_builder.select()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tooling update, replacing a bunch of dependencies with ruff which is faster and is quite compatible with the tools it replaces.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
